### PR TITLE
fix: inherit secrets in nodejs ci workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,3 +12,4 @@ on:
 jobs:
   build:
     uses: adobe/aio-reusable-workflows/.github/workflows/node.js.yml@main
+    secrets: inherit


### PR DESCRIPTION
fix: inherit secrets in nodejs ci workflow